### PR TITLE
Work around rari stdout pollution

### DIFF
--- a/scripts/generate-inventory.mts
+++ b/scripts/generate-inventory.mts
@@ -121,6 +121,14 @@ function installDeps() {
     encoding: "utf-8",
     stdio: "ignore",
   });
+
+  logger.info("Working around rari stdout pollution …");
+  // TODO: remove me when https://github.com/mdn/rari/issues/131 is fixed
+  execFileSync("yarn", ["--silent", "content", "validate-redirects"], {
+    cwd: destPath,
+    encoding: "utf-8",
+    stdio: "ignore",
+  });
 }
 
 function inventory() {


### PR DESCRIPTION
Builds have been failing since 10 February 2025. The cause is described in https://github.com/mdn/rari/issues/131. This PR works around that, by running another command before generating the inventory.

I ought to remove this when rari fixes this issue.