### PR TITLE
fix(scripts/generate-inventory): invoke rari with --quiet flag

### DIFF
--- a/scripts/generate-inventory.mts
+++ b/scripts/generate-inventory.mts
@@ -121,14 +121,6 @@ function installDeps() {
     encoding: "utf-8",
     stdio: "ignore",
   });
-
-  logger.info("Working around rari stdout pollution …");
-  // TODO: remove me when https://github.com/mdn/rari/issues/131 is fixed
-  execFileSync("yarn", ["--silent", "content", "validate-redirects"], {
-    cwd: destPath,
-    encoding: "utf-8",
-    stdio: "ignore",
-  });
 }
 
 function inventory() {

--- a/scripts/generate-inventory.mts
+++ b/scripts/generate-inventory.mts
@@ -132,7 +132,7 @@ function inventory() {
 
   logger.info("Generating content inventory…");
   const inventory = JSON.parse(
-    execFileSync("yarn", ["--silent", "run", "content", "inventory"], {
+    execFileSync("yarn", ["--silent", "run", "content", "--quiet", "inventory"], {
       ...readOpts,
       maxBuffer: 1024 * 1024 * 5,
     }),


### PR DESCRIPTION
Reverts c42fd624fe42077bb9d7677362b76b50d747c26e (workaround).

Cf. https://github.com/mdn/rari/issues/131#issuecomment-2659493840