### PR TITLE
Process inventory in chunks

### DIFF
--- a/lib/inventory.mts
+++ b/lib/inventory.mts
@@ -1,0 +1,226 @@
+import { Temporal } from "@js-temporal/polyfill";
+import assert from "node:assert/strict";
+import {
+  ExecFileSyncOptionsWithStringEncoding,
+  execFileSync,
+  spawn,
+} from "node:child_process";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { join, relative } from "node:path";
+import winston from "winston";
+
+const defaultLogger = winston.createLogger({
+  level: "warn",
+  format: winston.format.combine(
+    winston.format.colorize(),
+    winston.format.simple(),
+  ),
+  transports: new winston.transports.Console({
+    stderrLevels: ["debug", "warn", "info"],
+  }),
+});
+
+export class Inventory {
+  repo: string;
+  destPath: string;
+  logger: winston.Logger;
+
+  rawInventoryStdErr: string = "";
+  rawInventoryStdOut: string = "";
+  rawRedirects: string | undefined;
+
+  constructor(opts?: {
+    repo?: string;
+    destPath?: string;
+    logger?: winston.Logger;
+  }) {
+    const defaults = {
+      repo: "mdn/content",
+      destPath: relative(process.cwd(), ".mdn-content"), // TODO: use tempdir by default
+      logger: defaultLogger,
+    };
+    const resolvedOpts = { ...defaults, ...opts };
+
+    this.repo = resolvedOpts.repo;
+    this.destPath = resolvedOpts.destPath;
+    this.logger = resolvedOpts.logger;
+  }
+
+  async init(ref: string, date?: string) {
+    this.clone();
+    this.checkout(ref, date);
+    this.loadRedirects();
+    this.installDeps();
+    const result = await this.loadInventory();
+    if (result === null || result > 0) {
+      this.logger.error(this.rawInventoryStdErr);
+      throw new Error("Failed to load data. See stdout above for details.");
+    }
+  }
+
+  clone() {
+    if (
+      !existsSync(this.destPath) ||
+      !existsSync(join(this.destPath, "/.git"))
+    ) {
+      this.logger.info(`Cloning ${this.repo} to ${this.destPath}`);
+      execFileSync("gh", [
+        "repo",
+        "clone",
+        this.repo,
+        this.destPath,
+        "--",
+        "--filter=blob:none",
+        "--quiet",
+      ]);
+    } else {
+      this.logger.info(`Reusing existing clone at ${this.destPath}`);
+    }
+  }
+
+  checkout(ref: string, date?: string) {
+    this.logger.debug(`Fetching from origin`);
+    execFileSync("git", ["fetch", "origin"], { cwd: this.destPath });
+    if (date) {
+      const target = Temporal.PlainDate.from(date)
+        .toZonedDateTime({ timeZone: "UTC", plainTime: "00:00:01" })
+        .startOfDay();
+      this.logger.info(`Looking for commit on ${ref} at ${target.toString()}`);
+      const hash = execFileSync(
+        "git",
+        ["rev-list", "-1", `--before=${target.toString()}`, ref],
+        { cwd: this.destPath, encoding: "utf-8" },
+      )
+        .split("\n")
+        .filter((line) => line.length > 0)
+        .at(-1);
+      if (!hash) {
+        throw new Error(`Could not find commit near to ${target.toString()}`);
+      }
+      ref = hash;
+    }
+
+    this.logger.info(`Checking out ${ref}`);
+    execFileSync("git", ["switch", "--quiet", "--detach", ref], {
+      cwd: this.destPath,
+      encoding: "utf-8",
+    });
+  }
+
+  installDeps() {
+    this.logger.info("Installing dependencies…");
+    execFileSync("yarn", ["--silent"], {
+      cwd: this.destPath,
+      encoding: "utf-8",
+      stdio: "ignore",
+    });
+  }
+
+  loadInventory(): Promise<number | null> {
+    const process = spawn(
+      "yarn",
+      ["--silent", "run", "content", "--quiet", "inventory"],
+      { cwd: this.destPath },
+    );
+
+    process.stdout.setEncoding("utf-8");
+    process.stderr.setEncoding("utf-8");
+    process.stdout.on("data", (chunk: string) => {
+      this.rawInventoryStdOut = this.rawInventoryStdOut + chunk;
+    });
+    process.stderr.on("data", (chunk: string) => {
+      this.rawInventoryStdErr = this.rawInventoryStdErr + chunk;
+    });
+
+    return new Promise((resolve, reject) => {
+      process.on("error", (err) => {
+        reject(err);
+      });
+
+      process.on("close", (code) => {
+        resolve(code);
+      });
+    });
+  }
+
+  loadRedirects() {
+    this.rawRedirects = readFileSync(
+      `${this.destPath}/files/en-us/_redirects.txt`,
+      "utf8",
+    );
+  }
+
+  metadata() {
+    const readOpts: ExecFileSyncOptionsWithStringEncoding = {
+      cwd: this.destPath,
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf-8",
+    };
+
+    const commitShort = execFileSync(
+      "git",
+      ["rev-parse", "--short", "HEAD"],
+      readOpts,
+    )
+      .split("\n")
+      .filter((line) => line.length > 0)
+      .at(-1);
+    const commit = execFileSync("git", ["rev-parse", "HEAD"], readOpts)
+      .split("\n")
+      .filter((line) => line.length > 0)
+      .at(-1);
+
+    const authorInstant = execFileSync(
+      "git",
+      ["show", "--no-patch", "--format=%aI"],
+      readOpts,
+    )
+      .split("\n")
+      .filter((line) => line.length > 0)
+      .at(-1);
+    assert(authorInstant?.length);
+    const authorDate = Temporal.Instant.from(authorInstant)
+      .toZonedDateTimeISO("UTC")
+      .toString();
+
+    return { commit, commitShort, authorDate };
+  }
+
+  inventory() {
+    return JSON.parse(this.rawInventoryStdOut);
+  }
+
+  redirects() {
+    if (this.rawRedirects === undefined) {
+      throw new Error(
+        "Redirects haven't been loaded. Did you call `init()` or `loadRedirects()` first?",
+      );
+    }
+
+    const lines = this.rawRedirects.split("\n");
+    const redirectLines = lines.filter(
+      (line) => line.startsWith("/") && line.includes("\t"),
+    );
+    const redirectMap = new Map<string, string>();
+    for (const redirectLine of redirectLines) {
+      const [source, target] = redirectLine.split("\t", 2);
+      if (source && target) {
+        redirectMap.set(source, target);
+      }
+    }
+    return Object.fromEntries(redirectMap);
+  }
+
+  toObject() {
+    return {
+      metadata: this.metadata(),
+      inventory: this.inventory(),
+      redirects: this.redirects(),
+    };
+  }
+
+  cleanUp() {
+    this.logger.info("Cleaning up…");
+    rmSync(this.destPath, { recursive: true, force: true });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The MDN page inventory as a big JSON object.",
   "main": "src/index.mts",
   "scripts": {
-    "lint": "npx eslint .",
+    "lint": "npx eslint . --ignore-pattern '.mdn-content/*'",
     "test": "npx tsc --noEmit",
     "build": "npx tsx scripts/build.mts",
     "publish": "cd package && npm publish",

--- a/scripts/generate-inventory.mts
+++ b/scripts/generate-inventory.mts
@@ -1,14 +1,8 @@
-import { Temporal } from "@js-temporal/polyfill";
-import assert from "assert";
-import {
-  ExecFileSyncOptionsWithStringEncoding,
-  execFileSync,
-} from "child_process";
-import { existsSync, readFileSync, rmSync } from "fs";
-import { join, relative } from "path";
+import { relative } from "path";
 import { fileURLToPath } from "url";
 import winston from "winston";
 import yargs from "yargs";
+import { Inventory } from "../lib/inventory.mjs";
 
 const argv = yargs(process.argv.slice(2))
   .scriptName("dist")
@@ -49,149 +43,22 @@ const logger = winston.createLogger({
   }),
 });
 
-const MDNContentRepo = "mdn/content";
 const destPath = relative(process.cwd(), ".mdn-content");
 
-function main() {
+async function main() {
+  const inventory = new Inventory({ destPath, logger });
   try {
     if (argv.date) {
-      clone({ date: argv.date, ref: argv.ref });
+      await inventory.init(argv.ref, argv.date);
     } else {
-      clone({ ref: argv.ref });
+      await inventory.init(argv.ref);
     }
-    installDeps();
-    inventory();
+    console.log(JSON.stringify(inventory.toObject(), undefined, 2));
   } finally {
     if (argv.clean) {
-      cleanUp();
+      inventory.cleanUp();
     }
   }
-}
-
-function clone(opts: { ref: string; date?: string }) {
-  let { ref } = opts;
-
-  if (!existsSync(destPath) || !existsSync(join(destPath, "/.git"))) {
-    logger.info(`Cloning mdn/content into ${destPath}…`);
-    execFileSync("gh", [
-      "repo",
-      "clone",
-      MDNContentRepo,
-      destPath,
-      "--",
-      "--filter=blob:none",
-      "--quiet",
-    ]);
-  } else {
-    logger.info(`Reusing existing clone at ${destPath}…`);
-    execFileSync("git", ["fetch", "origin"]);
-  }
-
-  if (opts.date) {
-    // find commit on ref nearest to date
-    const target = Temporal.PlainDate.from(opts.date)
-      .toZonedDateTime({ timeZone: "UTC", plainTime: "00:00:01" })
-      .startOfDay();
-    logger.info(`Looking for commit on ${ref} at ${target.toString()}`);
-    const hash = execFileSync(
-      "git",
-      ["rev-list", "-1", `--before=${target.toString()}`, ref],
-      { cwd: destPath, encoding: "utf-8" },
-    )
-      .split("\n")
-      .filter((line) => line.length > 0)
-      .at(-1);
-    if (!hash) {
-      throw new Error(`Could not find commit near to ${target.toString()}`);
-    }
-    ref = hash;
-  }
-
-  logger.info(`Checking out ${ref}`);
-  execFileSync("git", ["switch", "--quiet", "--detach", ref], {
-    cwd: destPath,
-    encoding: "utf-8",
-  });
-}
-
-function installDeps() {
-  logger.info("Installing dependencies…");
-  execFileSync("yarn", ["--silent"], {
-    cwd: destPath,
-    encoding: "utf-8",
-    stdio: "ignore",
-  });
-}
-
-function inventory() {
-  const readOpts: ExecFileSyncOptionsWithStringEncoding = {
-    cwd: destPath,
-    stdio: ["ignore", "pipe", "ignore"],
-    encoding: "utf-8",
-  };
-
-  logger.info("Generating content inventory…");
-  const inventory = JSON.parse(
-    execFileSync("yarn", ["--silent", "run", "content", "--quiet", "inventory"], {
-      ...readOpts,
-      maxBuffer: 1024 * 1024 * 5,
-    }),
-  );
-
-  const commitShort = execFileSync(
-    "git",
-    ["rev-parse", "--short", "HEAD"],
-    readOpts,
-  )
-    .split("\n")
-    .filter((line) => line.length > 0)
-    .at(-1);
-  const commit = execFileSync("git", ["rev-parse", "HEAD"], readOpts)
-    .split("\n")
-    .filter((line) => line.length > 0)
-    .at(-1);
-
-  const authorInstant = execFileSync(
-    "git",
-    ["show", "--no-patch", "--format=%aI"],
-    readOpts,
-  )
-    .split("\n")
-    .filter((line) => line.length > 0)
-    .at(-1);
-  assert(authorInstant?.length);
-  const authorDate = Temporal.Instant.from(authorInstant)
-    .toZonedDateTimeISO("UTC")
-    .toString();
-
-  const redirects = (() => {
-    const file = readFileSync(`${destPath}/files/en-us/_redirects.txt`, "utf8");
-    const lines = file.split("\n");
-    const redirectLines = lines.filter(
-      (line) => line.startsWith("/") && line.includes("\t"),
-    );
-    const redirectMap = new Map<string, string>();
-    for (const redirectLine of redirectLines) {
-      const [source, target] = redirectLine.split("\t", 2);
-      if (source && target) {
-        redirectMap.set(source, target);
-      }
-    }
-    return Object.fromEntries(redirectMap);
-  })();
-
-  console.log(
-    JSON.stringify({
-      metadata: { commit, commitShort, authorDate },
-      inventory,
-      redirects,
-    }),
-  );
-}
-
-function cleanUp() {
-  logger.info("Cleaning up…");
-  rmSync(destPath, { recursive: true, force: true });
 }
 
 if (import.meta.url.startsWith("file:")) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,5 @@
     "noPropertyAccessFromIndexSignature": false,
     "outDir": "./dist"
   },
-  "include": ["./scripts/**/*.mts", "./package/index.mjs"]
+  "include": ["./lib/*.mts", "./package/index.mjs", "./scripts/*.mts"]
 }


### PR DESCRIPTION
This prevents recurring ENOBUFS errors and difficult debugging, due to the large JSON output of the MDN content inventory command.

This refactor also reduces the nesting of subprocesses, to reduce some debugging difficulty.