### PR TITLE
Improve ergonomics of backdating releases

### DIFF
--- a/lib/inventory.mts
+++ b/lib/inventory.mts
@@ -113,6 +113,7 @@ export class Inventory {
       cwd: this.destPath,
       encoding: "utf-8",
       stdio: "ignore",
+      env: { ...process.env, CI: "true" },
     });
   }
 


### PR DESCRIPTION
This adds a `dry-run` option, to see the results before committing to publishing a bunch of releases. It also adds a `continue` option, to allow setting a start date on the last known-good date, then filling any gaps.